### PR TITLE
[ENH] Update metadata fields that are kept in jsons

### DIFF
--- a/bidsifier/clean_metadata.py
+++ b/bidsifier/clean_metadata.py
@@ -14,20 +14,34 @@ def main(bids_dir):
     layout = BIDSLayout(bids_dir)
     scans = layout.get(extensions='nii.gz')
 
-    KEEP_KEYS = ['ConversionSoftware', 'ConversionSoftwareVersion',
-                 'EchoTime', 'EffectiveEchoSpacing', 'FlipAngle',
-                 'MagneticFieldStrength', 'Manufacturer',
-                 'ManufacturersModelName', 'PhaseEncodingDirection',
-                 'ProtocolName', 'RepetitionTime', 'ScanningSequence',
-                 'SequenceName', 'SequenceVariant', 'SeriesDescription',
-                 'SliceTiming', 'TaskName', 'FlipAngle', 'TotalReadoutTime',
-                 'EchoNumbers', 'EchoTrainLength', 'HighBit',
-                 'NumberOfAverages', 'Modality', 'ImagedNucleus',
-                 'ImagingFrequency', 'InPlanePhaseEncodingDirection',
-                 'MRAcquisitionType', 'NumberOfPhaseEncodingSteps',
-                 'PixelBandwidth', 'Rows', 'SAR', 'SliceLocation',
-                 'SliceThickness', 'SpacingBetweenSlices', 'IntendedFor',
-                 'MultibandAccelerationFactor', 'SeriesNumber']
+    KEEP_KEYS = [
+        'AnatomicalLandmarkCoordinates', 'AcquisitionDuration', 'CogAtlasID',
+        'CogPOID', 'CoilCombinationMethod', 'ConversionSoftware',
+        'ConversionSoftwareVersion', 'DelayAfterTrigger', 'DelayTime',
+        'DeviceSerialNumber', 'DwellTime', 'EchoNumbers', 'EchoTime',
+        'EchoTrainLength', 'EffectiveEchoSpacing', 'FlipAngle',
+        'GradientSetType', 'HighBit',
+        'ImagedNucleus', 'ImageType', 'ImagingFrequency',
+        'InPlanePhaseEncodingDirection', 'InstitutionName',
+        'InstitutionAddress', 'InstitutionalDepartmentName',
+        'Instructions', 'IntendedFor', 'InversionTime',
+        'MRAcquisitionType', 'MagneticFieldStrength', 'Manufacturer',
+        'ManufacturersModelName', 'MatrixCoilMode', 'Modality',
+        'MRTransmitCoilSequence', 'MultibandAccelerationFactor',
+        'NumberOfAverages', 'NumberOfPhaseEncodingSteps',
+        'NumberOfVolumesDiscardedByScanner', 'NumberOfVolumesDiscardedByUser',
+        'NumberShots', 'ParallelAcquisitionTechnique',
+        'ParallelReductionFactorInPlane', 'PartialFourier',
+        'PartialFourierDirection', 'PhaseEncodingDirection',
+        'PixelBandwidth', 'ProtocolName', 'PulseSequenceDetails',
+        'PulseSequenceType', 'ReceiveCoilActiveElements', 'ReceiveCoilName',
+        'RepetitionTime', 'Rows',
+        'SAR', 'ScanningSequence', 'ScanOptions', 'SequenceName',
+        'SequenceVariant', 'SeriesDescription', 'SeriesNumber',
+        'SliceEncodingDirection', 'SliceLocation',
+        'SliceThickness', 'SliceTiming', 'SoftwareVersions',
+        'SpacingBetweenSlices', 'StationName', 'TaskDescription',
+        'TaskName', 'TotalReadoutTime', 'Units', 'VolumeTiming']
 
     for scan in scans:
         json_file = scan.filename.replace('.nii.gz', '.json')


### PR DESCRIPTION
Closes #6.

I've gone through the BIDS specification again and have looked for any and all MRI-related fields mentioned. This should result in richer metadata, but the cleaning function should still remove extraneous fields.

Merging this will also require building a new Singularity image for the BIDSifier.