### PR TITLE
[ENH] Allow builtin heuristics

### DIFF
--- a/cis.py
+++ b/cis.py
@@ -126,7 +126,7 @@ def main(bids_dir, config, work_dir=None,
         op.join(
             proj_work_dir,
             '{0}-processed.txt'.format(config_options['project'])),
-        index=False)
+        sep='\t', line_terminator='\n', index=False)
 
     # Copy singularity images to scratch
     scratch_xnatdownload = op.join(work_dir, op.basename(xnatdownload_file))
@@ -214,7 +214,8 @@ def main(bids_dir, config, work_dir=None,
                     timedateobj, "%m/%d/%Y, %H:%M")
                 scans_df = scans_df.append(tmp_df)
                 scans_df.to_csv(
-                    op.join(raw_dir, 'scans.tsv'), sep='\t', index=False)
+                    op.join(raw_dir, 'scans.tsv'), sep='\t',
+                    line_terminator='\n', index=False)
 
                 # run cis_proc.py
                 err_file = op.join(

--- a/cis_proc.py
+++ b/cis_proc.py
@@ -105,13 +105,14 @@ def main(tar_file, bids_dir, config, sub, ses=None, work_dir=None, n_procs=1):
     out_deriv_dir = op.join(bids_dir,
                             'derivatives/mriqc-{0}'.format(mriqc_version))
 
-    # Additional checks and copying for heuristics file
-    heuristics_file = config_options['heuristics']
-    if not heuristics_file.startswith('/'):
-        heuristics_file = op.join(op.dirname(bids_dir), heuristics_file)
+    # Additional checks and copying for heuristic file
+    heuristic = config_options['heuristic']
 
-    if not op.isfile(heuristics_file):
-        raise ValueError('Heuristics file specified in config files must be '
+    if not heuristic.startswith('/'):
+        heuristic = op.join(op.dirname(bids_dir), heuristic)
+
+    if not op.isfile(heuristic):
+        raise ValueError('Heuristic file specified in config files must be '
                          'an existing file.')
     if not op.isfile(bidsifier_file):
         raise ValueError('BIDSifier image specified in config files must be '
@@ -127,7 +128,7 @@ def main(tar_file, bids_dir, config, sub, ses=None, work_dir=None, n_procs=1):
     if not op.isdir(bids_dir):
         os.makedirs(bids_dir)
 
-    shutil.copyfile(heuristics_file, op.join(scan_work_dir, 'heuristics.py'))
+    shutil.copyfile(heuristic, op.join(scan_work_dir, 'heuristic.py'))
 
     # Copy singularity images to scratch
     scratch_bidsifier = op.join(scan_work_dir, op.basename(bidsifier_file))
@@ -153,10 +154,10 @@ def main(tar_file, bids_dir, config, sub, ses=None, work_dir=None, n_procs=1):
     shutil.copyfile(tar_file, work_tar_file)
 
     # Run BIDSifier
-    cmd = ('{sing} -d {work} --heuristics {heur} --sub {sub} '
+    cmd = ('{sing} -d {work} --heuristic {heur} --sub {sub} '
            '--ses {ses} -o {outdir}'.format(
                sing=scratch_bidsifier, work=work_tar_file,
-               heur=op.join(scan_work_dir, 'heuristics.py'),
+               heur=op.join(scan_work_dir, 'heuristic.py'),
                sub=sub, ses=ses, outdir=op.join(scan_work_dir, 'bids')))
     run(cmd)
 

--- a/config/Dick_AHEAD.json
+++ b/config/Dick_AHEAD.json
@@ -1,7 +1,7 @@
 {
     "project": "Dick_AHEAD",
     "bidsifier": "cis_bidsify_v0.0.1-2018-08-24-04f91fa82d17.img",
-    "heuristics": "heuristics/Dick_AHEAD.py",
+    "heuristic": "heuristics/Dick_AHEAD.py",
     "mriqc": "poldracklab_mriqc_0.10.4-2018-03-23-8fb5f5e9184f.img",
     "mriqc_settings": {
         "fd_thres": 0.9

--- a/config/Mattfeld_RTV.json
+++ b/config/Mattfeld_RTV.json
@@ -1,7 +1,7 @@
 {
     "project": "Mattfeld_RTV",
     "bidsifier": "cis_bidsify_v0.0.1-2018-08-24-04f91fa82d17.img",
-    "heuristics": "heuristics/Mattfeld_RTV.py",
+    "heuristic": "heuristics/Mattfeld_RTV.py",
     "mriqc": "poldracklab_mriqc_0.10.4-2018-03-23-8fb5f5e9184f.img",
     "mriqc_settings": {
         "fd_thres": 0.5

--- a/config/Sutherland_ACE.json
+++ b/config/Sutherland_ACE.json
@@ -4,7 +4,7 @@
     "xnatdownload": "xnat_download_v0.0.3-2019-04-11-7651e03ddbc7.img",
     "protocol": "code/protocol.json",
     "bidsifier": "cis_bidsify_v0.0.1-2018-08-24-04f91fa82d17.img",
-    "heuristics": "code/heuristics.py",
+    "heuristic": "code/heuristic.py",
     "mriqc": "poldracklab_mriqc_0.10.4-2018-03-23-8fb5f5e9184f.img",
     "mriqc_options": {
         "anat": {

--- a/dataset.py
+++ b/dataset.py
@@ -30,7 +30,7 @@ def merge_datasets(scratch_bids_dir, bids_dir, project_name, sub, ses=None):
             [new_participants_df, orig_participants_df])
         new_participants_df.to_csv(
             op.join(bids_dir, 'participants.tsv'),
-            sep='\t', index=False)
+            sep='\t', line_terminator='\n', index=False)
     else:
         print('Subject/session already found in participants.tsv')
 
@@ -69,10 +69,11 @@ def merge_datasets(scratch_bids_dir, bids_dir, project_name, sub, ses=None):
         master_scans_df = pd.read_csv(master_scans_file, sep='\t')
         master_df_headers = list(master_scans_df)
         master_scans_df = master_scans_df.append(sub_scans_df)
-        master_scans_df.to_csv(master_scans_file, sep='\t', index=False,
+        master_scans_df.to_csv(master_scans_file, sep='\t',
+                               line_terminator='\n', index=False,
                                columns=master_df_headers)
     else:
         tmp_df_headers = list(sub_scans_df)
         sub_scans_df.to_csv(
-            master_scans_file, sep='\t',
+            master_scans_file, sep='\t', line_terminator='\n', 
             index=False, columns=tmp_df_headers)

--- a/dataset.py
+++ b/dataset.py
@@ -75,5 +75,5 @@ def merge_datasets(scratch_bids_dir, bids_dir, project_name, sub, ses=None):
     else:
         tmp_df_headers = list(sub_scans_df)
         sub_scans_df.to_csv(
-            master_scans_file, sep='\t', line_terminator='\n', 
+            master_scans_file, sep='\t', line_terminator='\n',
             index=False, columns=tmp_df_headers)

--- a/mriqc.py
+++ b/mriqc.py
@@ -121,7 +121,7 @@ def merge_mriqc_derivatives(scratch_deriv_dir, out_deriv_dir):
             new_df = pd.read_csv(csv_file)
             old_df = pd.read_csv(out_file)
             out_df = pd.concat((old_df, new_df))
-            out_df.to_csv(out_file, index=False)
+            out_df.to_csv(out_file, line_terminator='\n', index=False)
 
 
 def mriqc_group(bids_dir, config, work_dir=None, sub=None, ses=None,

--- a/utils.py
+++ b/utils.py
@@ -46,4 +46,4 @@ def clean_csv(in_file):
 
     df = pd.read_csv(in_file)
     df = df.fillna(0)
-    df.to_csv(out_file, index=False)
+    df.to_csv(out_file, line_terminator='\n', index=False)


### PR DESCRIPTION
Closes #35 and closes #49.

Changes proposed:
- Change "heuristics" to "heuristic" to match heudiconv convention.
- Add `line_separator='\n'` to all to_csv calls.
- Allow non-file heuristics (such as heudiconv builtins like reproin).